### PR TITLE
Remove tests with python 3.6

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
Because macos-latest no longer supports python 3.6